### PR TITLE
[NA] Fix theme selector

### DIFF
--- a/app/components/theme-config.ts
+++ b/app/components/theme-config.ts
@@ -1,0 +1,8 @@
+export type Theme = 'light' | 'dark';
+
+export const DEFAULT_THEME: Theme = 'dark';
+export const THEME_STORAGE_KEY = 'theme';
+
+export function isTheme(value: string | null): value is Theme {
+  return value === 'light' || value === 'dark';
+}

--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -2,8 +2,12 @@
 
 import React, { createContext, useEffect, useState } from 'react';
 import { track } from '@vercel/analytics';
-
-type Theme = 'light' | 'dark';
+import {
+  DEFAULT_THEME,
+  isTheme,
+  THEME_STORAGE_KEY,
+  type Theme,
+} from './theme-config';
 
 interface ThemeContextType {
   theme: Theme;
@@ -13,10 +17,12 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 function getPreferredTheme(): Theme {
-  if (typeof window === 'undefined') return 'dark';
+  if (typeof window === 'undefined') return DEFAULT_THEME;
 
-  const savedTheme = localStorage.getItem('theme');
-  if (savedTheme === 'light' || savedTheme === 'dark') {
+  // Keep this browser-side resolution logic in sync with the beforeInteractive
+  // script in app/layout.tsx so SSR hydration and client toggles agree.
+  const savedTheme = localStorage.getItem(THEME_STORAGE_KEY);
+  if (isTheme(savedTheme)) {
     return savedTheme;
   }
 
@@ -31,13 +37,10 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   const [theme, setTheme] = useState<Theme>(getPreferredTheme);
 
   const updateTheme = (nextTheme: Theme) => {
-    setTheme((currentTheme) => {
-      if (currentTheme !== nextTheme) {
-        track('theme_change', { theme: nextTheme });
-      }
+    if (theme === nextTheme) return;
 
-      return nextTheme;
-    });
+    setTheme(nextTheme);
+    track('theme_change', { theme: nextTheme });
   };
 
   useEffect(() => {
@@ -45,7 +48,7 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
 
     root.classList.toggle('dark', theme === 'dark');
     root.style.colorScheme = theme;
-    localStorage.setItem('theme', theme);
+    localStorage.setItem(THEME_STORAGE_KEY, theme);
   }, [theme]);
 
   return (

--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useEffect, useState } from 'react';
+import React, { createContext, useEffect, useRef, useState } from 'react';
 import { track } from '@vercel/analytics';
 import {
   DEFAULT_THEME,
@@ -35,12 +35,13 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const [theme, setTheme] = useState<Theme>(getPreferredTheme);
+  const shouldTrackThemeChangeRef = useRef(false);
 
   const updateTheme = (nextTheme: Theme) => {
     if (theme === nextTheme) return;
 
+    shouldTrackThemeChangeRef.current = true;
     setTheme(nextTheme);
-    track('theme_change', { theme: nextTheme });
   };
 
   useEffect(() => {
@@ -49,6 +50,11 @@ export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
     root.classList.toggle('dark', theme === 'dark');
     root.style.colorScheme = theme;
     localStorage.setItem(THEME_STORAGE_KEY, theme);
+
+    if (shouldTrackThemeChangeRef.current) {
+      shouldTrackThemeChangeRef.current = false;
+      track('theme_change', { theme });
+    }
   }, [theme]);
 
   return (

--- a/app/components/theme-provider.tsx
+++ b/app/components/theme-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { createContext, useEffect, useRef, useState } from 'react';
+import React, { createContext, useEffect, useState } from 'react';
 import { track } from '@vercel/analytics';
 
 type Theme = 'light' | 'dark';
@@ -12,33 +12,44 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
+function getPreferredTheme(): Theme {
+  if (typeof window === 'undefined') return 'dark';
+
+  const savedTheme = localStorage.getItem('theme');
+  if (savedTheme === 'light' || savedTheme === 'dark') {
+    return savedTheme;
+  }
+
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+    ? 'dark'
+    : 'light';
+}
+
 export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  const [theme, setTheme] = useState<Theme>(() => {
-    if (typeof window === 'undefined') return 'dark';
-    const savedTheme = localStorage.getItem('theme') as Theme | null;
-    if (savedTheme && (savedTheme === 'light' || savedTheme === 'dark')) {
-      return savedTheme;
-    }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light';
-  });
-  const hasTrackedRef = useRef(false);
+  const [theme, setTheme] = useState<Theme>(getPreferredTheme);
+
+  const updateTheme = (nextTheme: Theme) => {
+    setTheme((currentTheme) => {
+      if (currentTheme !== nextTheme) {
+        track('theme_change', { theme: nextTheme });
+      }
+
+      return nextTheme;
+    });
+  };
 
   useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
+    const root = document.documentElement;
+
+    root.classList.toggle('dark', theme === 'dark');
+    root.style.colorScheme = theme;
     localStorage.setItem('theme', theme);
-    if (hasTrackedRef.current) {
-      track('theme_change', { theme });
-    } else {
-      hasTrackedRef.current = true;
-    }
   }, [theme]);
 
   return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
+    <ThemeContext.Provider value={{ theme, setTheme: updateTheme }}>
       {children}
     </ThemeContext.Provider>
   );

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -1,18 +1,25 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useSyncExternalStore } from 'react';
+import { DEFAULT_THEME } from './theme-config';
 import { useTheme } from './theme-provider';
 import { MoonIcon, SunIcon } from './icons';
 
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   const [isHovered, setIsHovered] = useState(false);
+  const isHydrated = useSyncExternalStore(
+    () => () => {},
+    () => true,
+    () => false
+  );
 
   const toggleTheme = () => {
     setTheme(theme === 'light' ? 'dark' : 'light');
   };
 
-  const nextTheme = theme === 'light' ? 'dark' : 'light';
+  const displayTheme = isHydrated ? theme : DEFAULT_THEME;
+  const nextTheme = displayTheme === 'light' ? 'dark' : 'light';
 
   return (
     <button
@@ -21,11 +28,10 @@ export default function ThemeToggle() {
       onMouseLeave={() => setIsHovered(false)}
       className="p-2 rounded-full bg-gray-200 dark:bg-[#1c1c1c]/60 hover:opacity-80 transition-opacity duration-200 focus:outline-none cursor-pointer"
       aria-label={`Switch to ${nextTheme} mode`}
-      suppressHydrationWarning
       type="button"
     >
       <div className="flex items-center justify-center relative">
-        {theme === 'light' ? (
+        {displayTheme === 'light' ? (
           <MoonIcon />
         ) : (
           <SunIcon />

--- a/app/components/theme-toggle.tsx
+++ b/app/components/theme-toggle.tsx
@@ -1,21 +1,18 @@
 'use client';
 
-import { useState, useSyncExternalStore } from 'react';
+import { useState } from 'react';
 import { useTheme } from './theme-provider';
 import { MoonIcon, SunIcon } from './icons';
 
 export default function ThemeToggle() {
   const { theme, setTheme } = useTheme();
   const [isHovered, setIsHovered] = useState(false);
-  const isHydrated = useSyncExternalStore(
-    () => () => {},
-    () => true,
-    () => false
-  );
 
   const toggleTheme = () => {
     setTheme(theme === 'light' ? 'dark' : 'light');
   };
+
+  const nextTheme = theme === 'light' ? 'dark' : 'light';
 
   return (
     <button
@@ -23,26 +20,20 @@ export default function ThemeToggle() {
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}
       className="p-2 rounded-full bg-gray-200 dark:bg-[#1c1c1c]/60 hover:opacity-80 transition-opacity duration-200 focus:outline-none cursor-pointer"
-      aria-label={
-        isHydrated
-          ? `Switch to ${theme === 'light' ? 'dark' : 'light'} mode`
-          : 'Toggle theme'
-      }
+      aria-label={`Switch to ${nextTheme} mode`}
+      suppressHydrationWarning
+      type="button"
     >
       <div className="flex items-center justify-center relative">
-        {isHydrated ? (
-          theme === 'light' ? (
-            <MoonIcon />
-          ) : (
-            <SunIcon />
-          )
+        {theme === 'light' ? (
+          <MoonIcon />
         ) : (
-          <span className="block h-5 w-5" aria-hidden="true" />
+          <SunIcon />
         )}
         <div
           className={`absolute z-50 right-[-250%] w-8 text-center transition-opacity duration-150 ${isHovered ? 'opacity-100' : 'opacity-0'} sm:bottom-[-200%] sm:right-0 sm:w-16`}
         >
-          {theme === 'light' ? 'Dark' : 'Light'}
+          {nextTheme === 'dark' ? 'Dark' : 'Light'}
         </div>
       </div>
     </button>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,10 @@ import type { Metadata } from 'next';
 import { Space_Grotesk } from 'next/font/google';
 import Script from 'next/script';
 import PageLayout from './components/page-layout';
+import {
+  DEFAULT_THEME,
+  THEME_STORAGE_KEY,
+} from './components/theme-config';
 import { ThemeProvider } from './components/theme-provider';
 import './globals.css';
 
@@ -40,10 +44,15 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const defaultHtmlClassName =
+    DEFAULT_THEME === 'dark'
+      ? `${spaceGrotesk.className} dark`
+      : spaceGrotesk.className;
+
   return (
     <html
       lang="en"
-      className={`${spaceGrotesk.className} dark`}
+      className={defaultHtmlClassName}
       suppressHydrationWarning
       style={{ backgroundColor: '#232323' }}
     >
@@ -54,7 +63,7 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{
             __html: `(() => {
   try {
-    const savedTheme = localStorage.getItem('theme');
+    const savedTheme = localStorage.getItem('${THEME_STORAGE_KEY}');
     const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
     const theme = savedTheme === 'light' || savedTheme === 'dark'
       ? savedTheme
@@ -63,9 +72,10 @@ export default function RootLayout({
         : 'light';
     document.documentElement.classList.toggle('dark', theme === 'dark');
     document.documentElement.style.colorScheme = theme;
-    localStorage.setItem('theme', theme);
+    localStorage.setItem('${THEME_STORAGE_KEY}', theme);
   } catch {
-    document.documentElement.classList.add('dark');
+    document.documentElement.classList.toggle('dark', '${DEFAULT_THEME}' === 'dark');
+    document.documentElement.style.colorScheme = '${DEFAULT_THEME}';
   }
 })();`,
           }}


### PR DESCRIPTION
## What changed
- replaced the theme toggle hydration placeholder with direct icon rendering so the control always shows an icon
- simplified theme state initialization in the provider and kept DOM theme syncing in one place
- kept analytics tracking on explicit user theme changes instead of hydration-time state sync
- added `type="button"` to the toggle button

## Why it changed
The theme selector had regressed in two ways: the icon path could render empty during hydration, and the toggle path was not reliably syncing the document theme state when pressed.

## User impact
The theme selector on the home page now shows an icon immediately and switches between light and dark mode when clicked.

## Root cause
The toggle depended on a hydration-only placeholder path, which could leave the control without a rendered icon. The theme provider logic was also split between initialization and effect-driven syncing in a way that made the theme state harder to reason about.

## Validation
- `bun run lint` ✅
- `bun run build` ❌ fails in existing `Resend` route modules because `RESEND_API_KEY` is missing during build-time page data collection for `/api/subscribe` and `/api/send-newsletter`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hydration mismatch in the theme toggle to prevent display inconsistencies.

* **Improvements**
  * More reliable theme initialization and consistent color-scheme application to reduce flashes on load.
  * Theme persistence now uses a dedicated storage key.
  * Analytics for theme changes now only fire when the theme actually changes.

* **Usability**
  * Theme toggle button behavior, label, tooltip, and icon rendering made consistent and accessible (explicit button type and stable labels).

* **New Features**
  * Explicit default theme and validation for allowed theme values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->