### PR TITLE
fix: use goose.dev for email urls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,11 +34,11 @@ Scripts use `bun --bun` so local commands do not depend on PATH `node`.
 ## Env
 
 ```env
-VITE_PUBLIC_BASE_URL=https://goosewin.com
+VITE_PUBLIC_BASE_URL=https://goose.dev
 RESEND_AUDIENCE_ID=
 RESEND_API_KEY=
 NEWSLETTER_SECRET=
-SITE_URL=https://goosewin.com
+SITE_URL=https://goose.dev
 ```
 
 `VITE_` values are public. Keep secrets server-only.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# goosewin.com
+# goose.dev
 
-TanStack Start blog for goosewin.com.
+TanStack Start blog for goose.dev.
 
 ## Commands
 
@@ -36,11 +36,11 @@ Requires `jq`, `curl`, `SITE_URL`, and `NEWSLETTER_SECRET`.
 Create `.env.local` from `.env.example`.
 
 ```env
-VITE_PUBLIC_BASE_URL=https://goosewin.com
+VITE_PUBLIC_BASE_URL=https://goose.dev
 RESEND_AUDIENCE_ID=
 RESEND_API_KEY=
 NEWSLETTER_SECRET=
-SITE_URL=https://goosewin.com
+SITE_URL=https://goose.dev
 ```
 
 `VITE_` values are public. Keep secrets server-only.

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "goosewin.com",
-  "name": "goosewin.com",
+  "short_name": "goose.dev",
+  "name": "goose.dev",
   "icons": [
     {
       "src": "favicon.ico",

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,7 +3,7 @@ User-agent: *
 Allow: /
 
 # Host
-Host: https://goosewin.com
+Host: https://goose.dev
 
 # Sitemaps
-Sitemap: https://goosewin.com/sitemap.xml
+Sitemap: https://goose.dev/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://goosewin.com/about</loc><lastmod>2026-02-03T08:38:43.578Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/apple-icon.png</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/blog/2025-year-in-review</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/blog/adversity-creates-greatness</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/blog/devrel-the-goose-way</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/blog/education-is-overrated</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/blog</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/icon.png</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://goosewin.com/partners</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/about</loc><lastmod>2026-02-03T08:38:43.578Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/apple-icon.png</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/blog/2025-year-in-review</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/blog/adversity-creates-greatness</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/blog/devrel-the-goose-way</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/blog/education-is-overrated</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/blog</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/icon.png</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://goose.dev/partners</loc><lastmod>2026-02-03T08:38:43.579Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/scripts/send-newsletter.sh
+++ b/scripts/send-newsletter.sh
@@ -16,7 +16,7 @@
 #   ./scripts/send-newsletter.sh post1 post2 post3
 #
 # Environment variables required:
-#   SITE_URL - Your site URL (e.g., https://goosewin.com)
+#   SITE_URL - Your site URL (e.g., https://goose.dev)
 #   NEWSLETTER_SECRET - Secret for API authentication
 #
 

--- a/src/lib/og-image.server.tsx
+++ b/src/lib/og-image.server.tsx
@@ -107,7 +107,7 @@ export async function createSiteOgImageResponse() {
         position: 'relative',
       }}
     >
-      <img src={iconSrc} alt="goosewin.com icon" width={240} height={240} />
+      <img src={iconSrc} alt="goose.dev icon" width={240} height={240} />
     </div>,
     {
       ...size,
@@ -158,7 +158,7 @@ export async function createBlogPostOgImageResponse(post: BlogPost | null) {
       >
         <img
           src={iconSrc}
-          alt="goosewin.com icon"
+          alt="goose.dev icon"
           width={80}
           height={80}
           style={{ marginRight: 20 }}
@@ -189,7 +189,7 @@ export async function createBlogPostOgImageResponse(post: BlogPost | null) {
         <p style={{ fontSize: 24, opacity: 0.8 }}>
           Collection of thoughts by Dan Goosewin
         </p>
-        <p style={{ fontSize: 24, opacity: 0.8 }}>Read more at goosewin.com</p>
+        <p style={{ fontSize: 24, opacity: 0.8 }}>Read more at goose.dev</p>
       </div>
     </div>,
     {

--- a/src/lib/site.server.ts
+++ b/src/lib/site.server.ts
@@ -1,5 +1,7 @@
 import { getPublicBaseUrl, normalizeBaseUrl } from './site';
 
+export const EMAIL_FROM = 'Dan Goosewin <dan@goosewin.com>';
+
 export function getServerBaseUrl() {
   const siteUrl = process.env.SITE_URL?.trim();
   const baseUrl = siteUrl ? siteUrl : getPublicBaseUrl();

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,6 +1,7 @@
 export const SITE_NAME = 'Dan Goosewin';
 export const SITE_DESCRIPTION =
   'Dan Goosewin builds AI-native systems and publishes signal-first writing on software, execution, and leverage.';
+export const DEFAULT_PUBLIC_BASE_URL = 'https://goose.dev';
 
 export function normalizeBaseUrl(baseUrl: string) {
   return baseUrl.trim().replace(/\/+$/, '');
@@ -8,6 +9,6 @@ export function normalizeBaseUrl(baseUrl: string) {
 
 export function getPublicBaseUrl() {
   const baseUrl =
-    import.meta.env.VITE_PUBLIC_BASE_URL || 'https://goosewin.com';
+    import.meta.env.VITE_PUBLIC_BASE_URL || DEFAULT_PUBLIC_BASE_URL;
   return normalizeBaseUrl(baseUrl);
 }

--- a/src/routes/api/send-newsletter.ts
+++ b/src/routes/api/send-newsletter.ts
@@ -4,7 +4,7 @@ import { Resend } from 'resend';
 import { createElement } from 'react';
 import NewsletterEmail from '../../emails/newsletter';
 import { getBlogPost } from '../../lib/blog';
-import { getServerBaseUrl } from '../../lib/site.server';
+import { EMAIL_FROM, getServerBaseUrl } from '../../lib/site.server';
 
 function isNonEmptyString(value: unknown) {
   return typeof value === 'string' && value.trim().length > 0;
@@ -139,7 +139,7 @@ export const Route = createFileRoute('/api/send-newsletter')({
           const resend = new Resend(apiKey);
           const createResponse = await resend.broadcasts.create({
             audienceId,
-            from: 'Dan Goosewin <dan@goosewin.com>',
+            from: EMAIL_FROM,
             subject,
             html: emailHtml,
             send: true,

--- a/src/routes/api/subscribe.ts
+++ b/src/routes/api/subscribe.ts
@@ -3,7 +3,7 @@ import { render } from '@react-email/render';
 import { Resend } from 'resend';
 import { createElement } from 'react';
 import WelcomeEmail from '../../emails/welcome';
-import { getServerBaseUrl } from '../../lib/site.server';
+import { EMAIL_FROM, getServerBaseUrl } from '../../lib/site.server';
 
 function getEmailFromBody(body: unknown) {
   if (typeof body !== 'object' || body === null || !('email' in body)) {
@@ -103,7 +103,7 @@ export const Route = createFileRoute('/api/subscribe')({
           );
 
           const welcomeEmailResponse = await resend.emails.send({
-            from: 'Dan Goosewin <dan@goosewin.com>',
+            from: EMAIL_FROM,
             to: email,
             subject: 'Thanks for subscribing to my blog!',
             html: emailHtml,


### PR DESCRIPTION
## Summary
- use goose.dev as the default public/site URL for generated email links and images
- keep Resend sender as dan@goosewin.com
- update static site metadata/docs from goosewin.com to goose.dev

## Checks
- bun run format
- bun run lint
- bun run test
- bun --bun prettier --check .
- bunx --bun dotenv-linter .env.example
- bun run build
- VERCEL=1 bun run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated domain from `goosewin.com` to `goose.dev` across documentation, environment variables, SEO metadata, web manifest, and social media image descriptions.
  * Centralized email sender configuration for consistent branding in newsletter and subscription emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->