### PR TITLE
Move blog CI to Woodpecker

### DIFF
--- a/.github/workflows/newsletter.yml
+++ b/.github/workflows/newsletter.yml
@@ -1,41 +1,15 @@
-name: Send Newsletter for New Blog Posts
+# DISABLED 2026-05-28 - goosewin/blog CI and newsletter dispatch now run on
+# self-hosted Woodpecker. Keep this GitHub Actions workflow dispatch-only and
+# non-operational while GitHub Actions quota/billing is not the CI path.
+
+name: newsletter (disabled)
 
 on:
-  push:
-    branches: [main]
-    paths: ['posts/*.mdx']
   workflow_dispatch:
-    inputs:
-      dry_run:
-        description: Validate the newsletter without sending a Resend broadcast
-        required: true
-        type: boolean
-        default: true
-      slugs:
-        description: Optional space-separated post slugs to send or validate
-        required: false
-        type: string
 
 jobs:
-  send-newsletter:
+  noop:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-        with:
-          fetch-depth: 2 # Fetch current and previous commit to compare changes
-
-      - name: Send newsletter for new posts
-        env:
-          SITE_URL: ${{ secrets.SITE_URL }}
-          NEWSLETTER_SECRET: ${{ secrets.NEWSLETTER_SECRET }}
-          NEWSLETTER_DRY_RUN: ${{ inputs.dry_run || 'false' }}
-          NEWSLETTER_SLUGS: ${{ inputs.slugs || '' }}
-        run: |
-          if [ -n "$NEWSLETTER_SLUGS" ]; then
-            read -r -a slugs <<< "$NEWSLETTER_SLUGS"
-            bash scripts/send-newsletter.sh "${slugs[@]}"
-          else
-            bash scripts/send-newsletter.sh
-          fi
+      - name: Disabled
+        run: echo "Disabled. See .woodpecker/blog.yml and docs/ops/self-hosted-ci.md."

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+# Blog pre-commit gate. Mirrors the blocking Woodpecker checks.
+#
+# Bypass with `git commit --no-verify` only for intentional WIP.
+
+set -e
+
+echo "> lint"
+bun run lint
+
+echo "> format:check"
+bun run format:check
+
+echo "> typecheck"
+bun run typecheck
+
+echo "> test"
+bun run test
+
+echo "> build"
+bun run build
+
+echo "pre-commit gates passed"

--- a/.woodpecker/blog.yml
+++ b/.woodpecker/blog.yml
@@ -3,7 +3,7 @@ clone:
     image: woodpeckerci/plugin-git
     settings:
       partial: false
-      depth: 50
+      depth: 0
 
 steps:
   critical:

--- a/.woodpecker/blog.yml
+++ b/.woodpecker/blog.yml
@@ -7,8 +7,7 @@ clone:
 
 steps:
   critical:
-    image: goosewin-blog-ci:bun-1.3.14-jq-curl
-    pull: false
+    image: oven/bun:1.3.14-debian
     environment:
       CI: 'true'
       SITE_URL: https://goose.dev
@@ -24,8 +23,7 @@ steps:
       - event: [pull_request, push, manual]
 
   newsletter:
-    image: goosewin-blog-ci:bun-1.3.14-jq-curl
-    pull: false
+    image: oven/bun:1.3.14-debian
     environment:
       SITE_URL:
         from_secret: site_url
@@ -33,6 +31,8 @@ steps:
         from_secret: newsletter_secret
       NEWSLETTER_DRY_RUN: 'false'
     commands:
+      - apt-get update
+      - apt-get install -y --no-install-recommends ca-certificates curl git jq
       - bun run newsletter
     when:
       - event: push

--- a/.woodpecker/blog.yml
+++ b/.woodpecker/blog.yml
@@ -1,0 +1,40 @@
+clone:
+  git:
+    image: woodpeckerci/plugin-git
+    settings:
+      partial: false
+      depth: 50
+
+steps:
+  critical:
+    image: goosewin-blog-ci:bun-1.3.14-jq-curl
+    pull: false
+    environment:
+      CI: 'true'
+      SITE_URL: https://goose.dev
+      VITE_PUBLIC_BASE_URL: https://goose.dev
+    commands:
+      - bun install --frozen-lockfile
+      - bun run lint
+      - bun run format:check
+      - bun run typecheck
+      - bun run test
+      - bun run build
+    when:
+      - event: [pull_request, push, manual]
+
+  newsletter:
+    image: goosewin-blog-ci:bun-1.3.14-jq-curl
+    pull: false
+    environment:
+      SITE_URL:
+        from_secret: site_url
+      NEWSLETTER_SECRET:
+        from_secret: newsletter_secret
+      NEWSLETTER_DRY_RUN: 'false'
+    commands:
+      - bun run newsletter
+    when:
+      - event: push
+        branch: main
+        path: 'posts/*.mdx'

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ bun install
 bun dev
 bun run build
 bun run lint
+bun run typecheck
 bun run format
 ```
 
@@ -57,3 +58,11 @@ Manual deploy:
 ```bash
 bun run deploy
 ```
+
+## CI
+
+Self-hosted Woodpecker is the CI path for lint, tests, build, and automatic
+newsletter dispatch. See `docs/ops/self-hosted-ci.md`.
+
+The pre-commit hook runs lint, format check, typecheck, tests, and build through
+Bun before allowing a commit.

--- a/bun.lock
+++ b/bun.lock
@@ -34,6 +34,7 @@
         "@types/react-dom": "^19.2.0",
         "@vitejs/plugin-react": "^6.0.1",
         "eslint": "^10.2.1",
+        "husky": "^9.1.7",
         "jsdom": "^28.1.0",
         "prettier": "^3.8.1",
         "tsx": "^4.21.0",
@@ -917,6 +918,8 @@
     "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "httpxy": ["httpxy@0.5.1", "", {}, "sha512-JPhqYiixe1A1I+MXDewWDZqeudBGU8Q9jCHYN8ML+779RQzLjTi78HBvWz4jMxUD6h2/vUL12g4q/mFM0OUw1A=="],
+
+    "husky": ["husky@9.1.7", "", { "bin": { "husky": "bin.js" } }, "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA=="],
 
     "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 

--- a/docs/ops/self-hosted-ci.md
+++ b/docs/ops/self-hosted-ci.md
@@ -1,0 +1,71 @@
+# Self-hosted CI
+
+The blog uses self-hosted Woodpecker for CI and newsletter dispatch. GitHub
+Actions stays disabled while the Goosewin repos are using the Hetzner-backed
+Woodpecker path instead of GitHub-hosted Actions minutes.
+
+## Repo Contract
+
+The checked-in workflow is `.woodpecker/blog.yml`.
+
+The `critical` step runs on pushes, pull requests, and manual Woodpecker runs:
+
+- `bun install --frozen-lockfile`
+- `bun run lint`
+- `bun run format:check`
+- `bun run typecheck`
+- `bun run test`
+- `bun run build`
+
+The `newsletter` step runs only for pushes to `main` that add `posts/*.mdx`.
+It sends through the existing `scripts/send-newsletter.sh` path after the
+critical checks pass.
+
+## CI Image
+
+Build the pinned local image on the Woodpecker Docker host before enabling the
+repo. It includes the Bun version used locally plus `git`, `jq`, and `curl` for
+the newsletter script.
+
+```sh
+cat >/tmp/blog-ci.Dockerfile <<'EOF'
+FROM oven/bun:1.3.14-debian
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends bash ca-certificates curl git jq \
+  && rm -rf /var/lib/apt/lists/*
+RUN bun --version && git --version && jq --version && curl --version
+EOF
+
+docker build \
+  -f /tmp/blog-ci.Dockerfile \
+  -t goosewin-blog-ci:bun-1.3.14-jq-curl \
+  /tmp
+```
+
+## Woodpecker Setup
+
+1. Activate `goosewin/blog` in the existing `ci.goosewin.com` Woodpecker
+   instance.
+2. Keep the default pipeline path so Woodpecker discovers `.woodpecker/*.yml`.
+3. Enable push and pull-request hooks for the repo.
+4. Add repository secrets for the newsletter step:
+
+```sh
+woodpecker-cli repo secret add \
+  --repository goosewin/blog \
+  --name site_url \
+  --value https://goose.dev \
+  --event push
+
+woodpecker-cli repo secret add \
+  --repository goosewin/blog \
+  --name newsletter_secret \
+  --value <NEWSLETTER_SECRET> \
+  --event push
+```
+
+5. Require the Woodpecker `blog` status in GitHub branch protection. Do not
+   require the disabled GitHub Actions workflow.
+
+Manual newsletter sends should use `bun run newsletter -- <post-slug>` from a
+trusted shell with `SITE_URL` and `NEWSLETTER_SECRET` set.

--- a/docs/ops/self-hosted-ci.md
+++ b/docs/ops/self-hosted-ci.md
@@ -21,26 +21,9 @@ The `newsletter` step runs only for pushes to `main` that add `posts/*.mdx`.
 It sends through the existing `scripts/send-newsletter.sh` path after the
 critical checks pass.
 
-## CI Image
-
-Build the pinned local image on the Woodpecker Docker host before enabling the
-repo. It includes the Bun version used locally plus `git`, `jq`, and `curl` for
-the newsletter script.
-
-```sh
-cat >/tmp/blog-ci.Dockerfile <<'EOF'
-FROM oven/bun:1.3.14-debian
-RUN apt-get update \
-  && apt-get install -y --no-install-recommends bash ca-certificates curl git jq \
-  && rm -rf /var/lib/apt/lists/*
-RUN bun --version && git --version && jq --version && curl --version
-EOF
-
-docker build \
-  -f /tmp/blog-ci.Dockerfile \
-  -t goosewin-blog-ci:bun-1.3.14-jq-curl \
-  /tmp
-```
+Both steps use the pinned public `oven/bun:1.3.14-debian` image. The newsletter
+step installs `curl`, `git`, and `jq` at runtime because those tools are needed
+only for dispatch.
 
 ## Woodpecker Setup
 

--- a/docs/ops/self-hosted-ci.md
+++ b/docs/ops/self-hosted-ci.md
@@ -25,6 +25,10 @@ Both steps use the pinned public `oven/bun:1.3.14-debian` image. The newsletter
 step installs `curl`, `git`, and `jq` at runtime because those tools are needed
 only for dispatch.
 
+The clone step uses `depth: 0` so newsletter dispatch can compare against
+`CI_PREV_COMMIT_SHA` even after large pushes. The newsletter script still fetches
+the previous commit explicitly if a CI checkout is missing it.
+
 ## Woodpecker Setup
 
 1. Activate `goosewin/blog` in the existing `ci.goosewin.com` Woodpecker

--- a/package.json
+++ b/package.json
@@ -6,13 +6,17 @@
     "#/*": "./src/*"
   },
   "scripts": {
+    "prepare": "husky",
     "dev": "bun --bun vite dev --port 3000",
     "build": "bun --bun vite build",
     "preview": "bun --bun vite preview",
     "test": "bun --bun vitest run --config vitest.config.ts",
+    "typecheck": "bun --bun tsc --noEmit --pretty false",
     "lint": "bun --bun eslint .",
     "format": "bun --bun prettier --write .",
+    "format:check": "bun --bun prettier --check .",
     "check": "bun --bun prettier --write . && bun --bun eslint --fix",
+    "precommit": "bun run lint && bun run format:check && bun run typecheck && bun run test && bun run build",
     "newsletter": "bash scripts/send-newsletter.sh",
     "deploy": "bunx --bun vercel --prod",
     "start": "bun --bun .output/server/index.mjs"
@@ -47,6 +51,7 @@
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^6.0.1",
     "eslint": "^10.2.1",
+    "husky": "^9.1.7",
     "jsdom": "^28.1.0",
     "prettier": "^3.8.1",
     "tsx": "^4.21.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "format": "bun --bun prettier --write .",
     "format:check": "bun --bun prettier --check .",
     "check": "bun --bun prettier --write . && bun --bun eslint --fix",
-    "precommit": "bun run lint && bun run format:check && bun run typecheck && bun run test && bun run build",
     "newsletter": "bash scripts/send-newsletter.sh",
     "deploy": "bunx --bun vercel --prod",
     "start": "bun --bun .output/server/index.mjs"

--- a/scripts/send-newsletter.sh
+++ b/scripts/send-newsletter.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 #
 # Send Newsletter Script
-# 
+#
 # Usage:
-#   Automatic mode (GitHub Actions):
+#   Automatic mode (CI):
 #     ./scripts/send-newsletter.sh
 #     Detects new posts via git diff and sends newsletter
 #
@@ -69,24 +69,31 @@ if [ $# -gt 0 ]; then
       echo "Warning: Post file not found: $POST_FILE"
     fi
   done
-  
+
   # Remove trailing newline
   NEW_POSTS=$(echo "$NEW_POSTS" | sed '/^$/d')
-  
+
   if [ -z "$NEW_POSTS" ]; then
     echo "Error: No valid post files found"
     exit 1
   fi
 else
   echo "Automatic mode: Checking for new blog posts via git"
-  # Check for new blog posts using git diff
-  NEW_POSTS=$(git diff --name-only --diff-filter=A HEAD~1 HEAD | grep '^posts/.*\.mdx$' || true)
-  
+  BASE_COMMIT="${CI_PREV_COMMIT_SHA:-HEAD~1}"
+
+  if ! git rev-parse --verify "$BASE_COMMIT^{commit}" >/dev/null 2>&1; then
+    echo "Warning: Could not resolve base commit: $BASE_COMMIT"
+    NEW_POSTS=""
+  else
+    # Check for new blog posts using git diff
+    NEW_POSTS=$(git diff --name-only --diff-filter=A "$BASE_COMMIT" HEAD | grep '^posts/.*\.mdx$' || true)
+  fi
+
   if [ -z "$NEW_POSTS" ]; then
     echo "No new blog posts detected"
     exit 0
   fi
-  
+
   echo "New blog posts detected:"
   echo "$NEW_POSTS"
 fi

--- a/scripts/send-newsletter.sh
+++ b/scripts/send-newsletter.sh
@@ -82,12 +82,17 @@ else
   BASE_COMMIT="${CI_PREV_COMMIT_SHA:-HEAD~1}"
 
   if ! git rev-parse --verify "$BASE_COMMIT^{commit}" >/dev/null 2>&1; then
-    echo "Warning: Could not resolve base commit: $BASE_COMMIT"
-    NEW_POSTS=""
-  else
-    # Check for new blog posts using git diff
-    NEW_POSTS=$(git diff --name-only --diff-filter=A "$BASE_COMMIT" HEAD | grep '^posts/.*\.mdx$' || true)
+    echo "Base commit not present in checkout, fetching: $BASE_COMMIT"
+    git fetch --no-tags --depth=1 origin "$BASE_COMMIT"
   fi
+
+  if ! git rev-parse --verify "$BASE_COMMIT^{commit}" >/dev/null 2>&1; then
+    echo "Error: Could not resolve base commit: $BASE_COMMIT"
+    exit 1
+  fi
+
+  # Check for new blog posts using git diff
+  NEW_POSTS=$(git diff --name-only --diff-filter=A "$BASE_COMMIT" HEAD | grep '^posts/.*\.mdx$' || true)
 
   if [ -z "$NEW_POSTS" ]; then
     echo "No new blog posts detected"

--- a/src/components/route-transition-manager.tsx
+++ b/src/components/route-transition-manager.tsx
@@ -9,6 +9,7 @@ export default function RouteTransitionManager() {
 
   useEffect(() => {
     let cleanupTimer: number | undefined;
+    const root = document.documentElement;
     const clearCleanupTimer = () => {
       if (cleanupTimer !== undefined) {
         window.clearTimeout(cleanupTimer);
@@ -27,17 +28,17 @@ export default function RouteTransitionManager() {
       });
 
       if (typeof document.startViewTransition === 'function') {
-        document.documentElement.dataset.routeTransition = direction;
+        root.dataset.routeTransition = direction;
       } else {
-        document.documentElement.dataset.routeTransitionFallback = direction;
+        root.dataset.routeTransitionFallback = direction;
       }
     });
 
     const unsubscribeResolved = router.subscribe('onResolved', () => {
       clearCleanupTimer();
       cleanupTimer = window.setTimeout(() => {
-        delete document.documentElement.dataset.routeTransition;
-        delete document.documentElement.dataset.routeTransitionFallback;
+        delete root.dataset.routeTransition;
+        delete root.dataset.routeTransitionFallback;
       }, 500);
     });
 


### PR DESCRIPTION
## Summary
- Add a Woodpecker pipeline for blog lint, format check, typecheck, tests, build, and newsletter dispatch.
- Disable the GitHub Actions newsletter workflow while CI runs on self-hosted Woodpecker.
- Add Husky pre-commit gates and fix the existing route transition typecheck issue.

## Verification
- Pre-commit hook ran during commit: lint, format:check, typecheck, test, build.
- bun install --frozen-lockfile.
