### PR TITLE
fix: harden Bun-version guard to detect the invoking package manager

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,9 +1,14 @@
 #!/usr/bin/env sh
-# Blog pre-commit gate. Mirrors the blocking Woodpecker checks.
+# Blog pre-commit gate. Mirrors the blocking Woodpecker checks, and guards the
+# Bun version so a commit can't be produced under a Bun that ignores the
+# bunfig.toml minimumReleaseAge cooldown (added in Bun 1.3).
 #
 # Bypass with `git commit --no-verify` only for intentional WIP.
 
 set -e
+
+echo "> bun version"
+bun scripts/check-bun-version.ts
 
 echo "> lint"
 bun run lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,10 +80,18 @@ Newsletter sending depends on `jq`, `curl`, `SITE_URL`, and
   by design. To bump a brand-new version of any other package before the
   cooldown elapses, run `bun install --minimum-release-age=0` deliberately.
 - Requires Bun >= 1.3 (`minimumReleaseAge` was added in 1.3; older Bun and
-  non-Bun managers ignore it silently). `engines.bun` declares this and a
-  `preinstall` guard (`scripts/check-bun-version.ts`) hard-fails the install on
-  unsupported versions so the cooldown can never be a silent no-op. Vercel's
-  `bunVersion: "1.x"` auto-resolves to a current 1.3.x, so deploys enforce it.
+  non-Bun managers ignore it silently). Declared via `engines.bun` and
+  `packageManager`. The `preinstall` guard (`scripts/check-bun-version.ts`)
+  inspects `npm_config_user_agent` — the _invoking_ manager, not the hook's own
+  runtime — so `npm`/`yarn`/`pnpm` and Bun < 1.3 hard-fail the install; the
+  `.husky/pre-commit` hook runs the same guard so an old Bun can't commit a
+  lockfile that skipped the cooldown.
+- Authoritative enforcement is the Woodpecker `critical` step
+  (`.woodpecker/blog.yml`, `oven/bun:1.3.14-debian`): lifecycle hooks are
+  best-effort locally, so CI re-runs `bun install --frozen-lockfile` on a pinned
+  Bun. GitHub Actions stays disabled (see `docs/ops/self-hosted-ci.md`).
+  Vercel's `bunVersion: "1.x"` resolves to a current 1.3.x, so deploys enforce
+  it too.
 
 ## Next
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "bun": ">=1.3.0"
   },
+  "packageManager": "bun@1.3.14",
   "imports": {
     "#/*": "./src/*"
   },

--- a/scripts/check-bun-version.ts
+++ b/scripts/check-bun-version.ts
@@ -1,24 +1,46 @@
-// Install-time guard.
+// Install-time guard for the bunfig.toml `minimumReleaseAge` cooldown.
 //
-// The minimumReleaseAge supply-chain cooldown in bunfig.toml was added in
-// Bun 1.3. Older Bun versions (and non-Bun package managers) silently ignore
-// the setting, turning the cooldown into a no-op and giving false confidence.
-// Fail the install loudly instead of skipping the gate quietly.
+// `minimumReleaseAge` only exists in Bun >= 1.3. Older Bun and non-Bun managers
+// (npm/yarn/pnpm) ignore the setting, so the supply-chain cooldown would be a
+// silent no-op. This hook always executes under `bun` (its command is
+// `bun scripts/...`), so `process.versions.bun` can't tell us who *invoked* the
+// install — `npm install` on a Bun-equipped machine would still pass. We read
+// `npm_config_user_agent` instead, which reflects the invoking package manager
+// and its version (e.g. "bun/1.3.14 npm/? node/..." vs "npm/11.12.1 node/...").
 
-const bunVersion = (process.versions as Record<string, string | undefined>).bun;
-
-if (!bunVersion) {
+function fail(message: string): never {
   console.error(
-    'This project must be installed with Bun >= 1.3 — other package managers ignore the bunfig.toml minimumReleaseAge cooldown. Install Bun: https://bun.sh'
+    `\n[install blocked] ${message}\nSee the Dependency policy in AGENTS.md.\n`
   );
   process.exit(1);
 }
 
-const [major = 0, minor = 0] = bunVersion.split('.').map(Number);
+const userAgent = process.env.npm_config_user_agent ?? '';
+const bunMatch = /(?:^|\s)bun\/(\d+)\.(\d+)\.\d+/.exec(userAgent);
+
+if (!bunMatch) {
+  // No "bun/x.y.z" in the user agent: either a non-Bun manager invoked the
+  // install, or the script was run directly with no user agent (e.g. a git
+  // hook). Trust the runtime only in the latter (no-agent) case.
+  const runtime = (process.versions as Record<string, string | undefined>).bun;
+  const [rMajor = 0, rMinor = 0] = (runtime ?? '').split('.').map(Number);
+
+  if (userAgent === '' && (rMajor > 1 || (rMajor === 1 && rMinor >= 3))) {
+    process.exit(0);
+  }
+
+  fail(
+    `this project must be installed with Bun >= 1.3 (saw "${userAgent || 'no package-manager user agent'}"). ` +
+      `Other package managers ignore the bunfig.toml minimumReleaseAge cooldown. Install Bun: https://bun.sh`
+  );
+}
+
+const major = Number(bunMatch[1]);
+const minor = Number(bunMatch[2]);
 
 if (major < 1 || (major === 1 && minor < 3)) {
-  console.error(
-    `Bun ${bunVersion} is too old: the minimumReleaseAge cooldown in bunfig.toml was added in Bun 1.3 and is silently ignored by older versions. Run: bun upgrade`
+  fail(
+    `Bun ${major}.${minor}.x is too old — minimumReleaseAge was added in Bun 1.3 and is silently ignored ` +
+      `by older versions. Upgrade with: bun upgrade`
   );
-  process.exit(1);
 }


### PR DESCRIPTION
Follow-up to #14, which merged before the reviewer feedback on the
`preinstall` guard was addressed — so the issues below are currently live in
`main`. This PR fixes them.

## Critical feedback being resolved (from #14)

- **Cursor Bugbot (Medium)** + **Codex (P2)** — *Guard can't detect non-Bun managers.* The `preinstall` hook is `bun scripts/check-bun-version.ts`, so it always runs under Bun and `process.versions.bun` is always set. `npm install` / `yarn` / `pnpm` on a Bun-equipped machine therefore **passed** and silently bypassed the `bunfig.toml` `minimumReleaseAge` cooldown.
- **Codex (P2)** — *Move the guard before resolution.* On Bun < 1.3 the root `preinstall` runs after resolution, so an old Bun could write a fresh version into `bun.lock` before the guard fired.
- **Codex (P2)** — *Pin a Bun version / packageManager.*

## Changes

- **`scripts/check-bun-version.ts`** now reads `npm_config_user_agent` — the *invoking* manager and its version (`bun/1.3.14 npm/? …` vs `npm/11.12.1 …`) — instead of the hook's own runtime. `npm`/`yarn`/`pnpm` and Bun < 1.3 now hard-fail.
- **`.husky/pre-commit`** runs the same guard, so an old/non-Bun toolchain can't *commit* a lockfile that skipped the cooldown — closing the "before resolution" gap at the commit boundary (the merge added husky).
- **`package.json`** pins `packageManager: "bun@1.3.14"` (alongside the existing `engines.bun`).
- **`AGENTS.md`** documents the guard semantics and points at the authoritative gate — the Woodpecker `critical` step (`oven/bun:1.3.14-debian`, `bun install --frozen-lockfile`). GitHub Actions intentionally stays disabled per `docs/ops/self-hosted-ci.md`.

## Verification

Guard exit codes by invoking user agent:

| user agent | exit |
|---|---|
| `npm/11 …` | 1 (blocked) |
| `yarn/4 …` | 1 (blocked) |
| `bun/1.2.14 …` | 1 (blocked) |
| `bun/1.3.14 …` | 0 (allowed) |
| no agent (direct/git hook) → runtime ≥ 1.3 | 0 (allowed) |

Full pre-commit/Woodpecker gate passes locally: `bun install --frozen-lockfile` (no lockfile drift), `lint`, `format:check`, `typecheck`, `test`, `build`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added explicit Bun package manager specification to project configuration.
  * Enhanced pre-commit validation to enforce minimum Bun version compatibility; commits will now fail if Bun version does not meet requirements (bypassed via `--no-verify`).
  * Improved version detection logic for better accuracy.

* **Documentation**
  * Updated package manager and dependency policy documentation to clarify Bun version requirements and enforcement mechanisms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/goosewin/blog/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->