### PR TITLE
fix(seo): per-page og:url, default og:image, www canonical, JSON-LD

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,14 +34,16 @@ Scripts use `bun --bun` so local commands do not depend on PATH `node`.
 ## Env
 
 ```env
-VITE_PUBLIC_BASE_URL=https://goose.dev
+VITE_PUBLIC_BASE_URL=https://www.goose.dev
 RESEND_AUDIENCE_ID=
 RESEND_API_KEY=
 NEWSLETTER_SECRET=
-SITE_URL=https://goose.dev
+SITE_URL=https://www.goose.dev
 ```
 
-`VITE_` values are public. Keep secrets server-only.
+`VITE_` values are public. Keep secrets server-only. The canonical host is
+`www.goose.dev`; `VITE_PUBLIC_BASE_URL` and `SITE_URL` must use it (they feed
+canonical/OG/sitemap URLs and override the code default).
 
 ## Deployment
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -3,7 +3,7 @@ User-agent: *
 Allow: /
 
 # Host
-Host: https://goose.dev
+Host: https://www.goose.dev
 
 # Sitemaps
-Sitemap: https://goose.dev/sitemap.xml
+Sitemap: https://www.goose.dev/sitemap.xml

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -1,7 +1,7 @@
 export const SITE_NAME = 'Dan Goosewin';
 export const SITE_DESCRIPTION =
   'Dan Goosewin builds AI-native systems and publishes signal-first writing on software, execution, and leverage.';
-const DEFAULT_PUBLIC_BASE_URL = 'https://goose.dev';
+const DEFAULT_PUBLIC_BASE_URL = 'https://www.goose.dev';
 
 export function normalizeBaseUrl(baseUrl: string) {
   return baseUrl.trim().replace(/\/+$/, '');

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -22,9 +22,11 @@ export const Route = createRootRouteWithContext()({
         { property: 'og:site_name', content: SITE_NAME },
         { property: 'og:title', content: SITE_NAME },
         { property: 'og:description', content: SITE_DESCRIPTION },
+        { property: 'og:image', content: `${baseUrl}/opengraph-image` },
         { name: 'twitter:card', content: 'summary_large_image' },
         { name: 'twitter:site', content: '@goosewin' },
         { name: 'twitter:creator', content: '@goosewin' },
+        { name: 'twitter:image', content: `${baseUrl}/opengraph-image` },
       ],
       links: [
         {

--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -14,6 +14,7 @@ export const Route = createFileRoute('/about')({
           content:
             "I'm a software engineer and founder building AI-native products in San Francisco. I focus on systems, execution, and product narratives that matter in AI.",
         },
+        { property: 'og:url', content: `${baseUrl}/about` },
       ],
       links: [{ rel: 'canonical', href: `${baseUrl}/about` }],
     };

--- a/src/routes/blog.$slug.tsx
+++ b/src/routes/blog.$slug.tsx
@@ -63,6 +63,7 @@ export const Route = createFileRoute('/blog/$slug')({
         { property: 'og:type', content: 'article' },
         { property: 'article:published_time', content: post.date },
         { property: 'article:author', content: 'Dan Goosewin' },
+        { property: 'og:url', content: `${baseUrl}/blog/${post.slug}` },
         { property: 'og:image', content: image },
         { name: 'twitter:card', content: 'summary_large_image' },
         { name: 'twitter:title', content: post.title },

--- a/src/routes/blog.index.tsx
+++ b/src/routes/blog.index.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import BackLink from '../components/back-link';
 import BlogPostList from '../components/blog-post-list';
 import SubscriptionForm from '../components/subscription-form';
+import StructuredData from '../components/structured-data';
 import { getAllBlogPosts } from '../lib/blog';
 import { getPublicBaseUrl } from '../lib/site';
 
@@ -14,6 +15,7 @@ export const Route = createFileRoute('/blog/')({
         name: 'description',
         content: 'Opinionated writing on software, execution, and leverage.',
       },
+      { property: 'og:url', content: `${getPublicBaseUrl()}/blog` },
     ],
     links: [{ rel: 'canonical', href: `${getPublicBaseUrl()}/blog` }],
   }),
@@ -22,9 +24,26 @@ export const Route = createFileRoute('/blog/')({
 
 function Blog() {
   const posts = Route.useLoaderData();
+  const baseUrl = getPublicBaseUrl();
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@type': 'Blog',
+    '@id': `${baseUrl}/blog`,
+    url: `${baseUrl}/blog`,
+    name: 'Dan Goosewin',
+    description: 'Opinionated writing on software, execution, and leverage.',
+    author: { '@type': 'Person', name: 'Dan Goosewin', url: baseUrl },
+    blogPost: posts.map((post) => ({
+      '@type': 'BlogPosting',
+      headline: post.title,
+      url: `${baseUrl}/blog/${post.slug}`,
+      datePublished: post.date,
+    })),
+  };
 
   return (
     <div className="space-y-10">
+      <StructuredData data={structuredData} />
       <BackLink />
       <h1 className="text-4xl font-black tracking-tight sm:text-5xl">Blog</h1>
       <BlogPostList posts={posts} showDate />

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,9 +1,10 @@
 import { Link, createFileRoute } from '@tanstack/react-router';
 import BlogPostList from '../components/blog-post-list';
+import StructuredData from '../components/structured-data';
 import ThemeToggle from '../components/theme-toggle';
 import { ArrowUpRightIcon } from '../components/icons';
 import { getAllBlogPosts } from '../lib/blog';
-import { getPublicBaseUrl } from '../lib/site';
+import { SITE_DESCRIPTION, SITE_NAME, getPublicBaseUrl } from '../lib/site';
 
 export const Route = createFileRoute('/')({
   loader: () => getAllBlogPosts(),
@@ -22,9 +23,32 @@ const socialLinks = [
 function Home() {
   const posts = Route.useLoaderData();
   const latestPosts = posts.slice(0, 4);
+  const baseUrl = getPublicBaseUrl();
+  const structuredData = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'WebSite',
+        '@id': `${baseUrl}/#website`,
+        url: baseUrl,
+        name: SITE_NAME,
+        description: SITE_DESCRIPTION,
+        publisher: { '@id': `${baseUrl}/#person` },
+      },
+      {
+        '@type': 'Person',
+        '@id': `${baseUrl}/#person`,
+        name: SITE_NAME,
+        url: baseUrl,
+        description: SITE_DESCRIPTION,
+        sameAs: socialLinks.map((link) => link.href),
+      },
+    ],
+  };
 
   return (
     <div className="space-y-16">
+      <StructuredData data={structuredData} />
       <header className="space-y-6">
         <div className="flex items-start justify-between gap-4">
           <h1 className="text-5xl font-black leading-[0.95] tracking-tight sm:text-6xl">

--- a/src/routes/partners.tsx
+++ b/src/routes/partners.tsx
@@ -53,6 +53,7 @@ export const Route = createFileRoute('/partners')({
           content:
             'A running list of customers and collaborators across past, current, and future work.',
         },
+        { property: 'og:url', content: `${baseUrl}/partners` },
       ],
       links: [{ rel: 'canonical', href: `${baseUrl}/partners` }],
     };


### PR DESCRIPTION
Fixes the SEO gaps found auditing production (goose.dev).

## Bugs fixed
1. **`og:url` was the homepage on every page.** [__root.tsx](src/routes/__root.tsx) set `og:url` to `baseUrl` and no route overrode it — `/blog`, every post, `/about`, `/partners` all told crawlers/social their URL was the homepage. Now set per-page to match canonical.
2. **No default `og:image`/`twitter:image`.** Only posts had one, so home/blog/about/partners shared with no preview card. Added a default `/opengraph-image` in the root meta (posts still override with their own).
3. **www vs non-www mismatch.** Prod serves `www.goose.dev` (apex 307→www), but canonical/OG/sitemap/robots used apex `goose.dev`. Switched the canonical host to **www.goose.dev** (base-URL default + robots.txt).

## Also
- **JSON-LD** added: `WebSite` + `Person` on the homepage, `Blog` (+ `BlogPosting` list) on `/blog`. (Posts already had `BlogPosting`; `/partners` already had `ItemList`.)

## ⚠️ Required production change
`VITE_PUBLIC_BASE_URL` and `SITE_URL` in Vercel are currently `https://goose.dev` and **must be updated to `https://www.goose.dev`** — they override the code default and feed canonical/OG/sitemap URLs. The existing apex→www redirect already matches www, so no domain-redirect change is needed.

## Verification
Built the production server locally and curled every page type:

| Page | og:url | og:image | canonical | JSON-LD |
|---|---|---|---|---|
| `/` | `www.goose.dev` | `…/opengraph-image` | `www.goose.dev` | WebSite + Person |
| `/blog` | `…/blog` | `…/opengraph-image` | `…/blog` | Blog + 5 BlogPosting |
| `/about` | `…/about` | `…/opengraph-image` | `…/about` | — |
| post | `…/blog/<slug>` | post image | post URL | BlogPosting+Person+WebPage |

`lint`, `format:check`, `typecheck`, `test`, `build` all green (husky + Woodpecker gate).

Audit context: production E2E (all routes 200, real 404), accessibility (axe: 0 violations), performance (TTFB 53ms, 206KB/19 req, CLS 0), and Vercel Analytics (beacon firing) were all verified healthy — SEO was the only area needing fixes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Open Graph meta tags for improved social media sharing previews across all pages.
  * Added structured data support for better search engine understanding of blog and homepage content.

* **Chores**
  * Standardized canonical URL configuration across settings and documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/goosewin/blog/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->