### PR TITLE
fix: update about page bio

### DIFF
--- a/src/routes/about.tsx
+++ b/src/routes/about.tsx
@@ -12,7 +12,7 @@ export const Route = createFileRoute('/about')({
         {
           name: 'description',
           content:
-            "I'm a software engineer and founder building AI-native products in San Francisco. I focus on systems, execution, and product narratives that matter in AI.",
+            "I'm a software engineer and founder building AI-native products. I focus on systems, execution, and product narratives that matter in AI.",
         },
         { property: 'og:url', content: `${baseUrl}/about` },
       ],
@@ -42,7 +42,19 @@ function About() {
           output.
         </p>
         <p className="text-balance text-gray-600 dark:text-gray-400">
-          Based in California.
+          Previously DevRel Lead at Vapi in San Francisco. Now fractional DevRel
+          through my own company, Goosewin Media Group, helping devtools and AI
+          companies win developer mindshare. I also talk about tech, AI, and the
+          change ahead on{' '}
+          <a
+            href="https://youtube.com/@dan_goosewin"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline-link"
+          >
+            YouTube
+          </a>
+          .
         </p>
         <p className="text-balance text-gray-600 dark:text-gray-400">
           I care about leverage, speed, and clarity. I love products and teams


### PR DESCRIPTION
## What changed

- Removed the stale "in San Francisco" location from the about page meta description.
- Replaced the "Based in California." line with current status: previously DevRel Lead at Vapi in San Francisco, now fractional DevRel through Goosewin Media Group helping devtools and AI companies win developer mindshare, with a link to the YouTube channel.

## Why

The about page predated the move away from SF (see the Leaving San Francisco post) and didn't reflect the fractional DevRel work under Goosewin Media Group.

## Notes for review

- Only `src/routes/about.tsx` changed; homepage and site-wide description still say "software engineer and founder building AI-native products" — left as-is intentionally, can follow up if that framing should change too.
- `bun format` and `bun run lint` pass (0 errors, 7 pre-existing warnings).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the About page description to use broader, location-neutral wording.
  * Expanded the biography with professional background, current focus, speaking topics, and a YouTube link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->